### PR TITLE
Match Aurorae titlebar colors to GTK theme.

### DIFF
--- a/aurorae/themes/Qogir-dark-circle/Qogir-dark-circlerc
+++ b/aurorae/themes/Qogir-dark-circle/Qogir-dark-circlerc
@@ -1,11 +1,11 @@
 [General]
 ActiveFocusedTabColor=78,78,78
-ActiveTextColor=177,178,183,255
+ActiveTextColor=207,214,219,255
 ActiveTextShadowColor=255,255,255,255
 ActiveUnfocusedTabColor=120,120,120
 
 InactiveFocusedTabColor=120,120,120
-InactiveTextColor=138,143,152,255
+InactiveTextColor=169,175,180,255
 InactiveTextShadowColor=255,255,255,255
 InactiveUnfocusedTabColor=120,120,120
 

--- a/aurorae/themes/Qogir-dark/Qogir-darkrc
+++ b/aurorae/themes/Qogir-dark/Qogir-darkrc
@@ -1,11 +1,11 @@
 [General]
 ActiveFocusedTabColor=78,78,78
-ActiveTextColor=177,178,183,255
+ActiveTextColor=207,214,219,255
 ActiveTextShadowColor=255,255,255,255
 ActiveUnfocusedTabColor=120,120,120
 
 InactiveFocusedTabColor=120,120,120
-InactiveTextColor=138,143,152,255
+InactiveTextColor=169,175,180,255
 InactiveTextShadowColor=255,255,255,255
 InactiveUnfocusedTabColor=120,120,120
 

--- a/aurorae/themes/Qogir/Qogirrc
+++ b/aurorae/themes/Qogir/Qogirrc
@@ -1,11 +1,11 @@
 [General]
 ActiveFocusedTabColor=78,78,78
-ActiveTextColor=177,178,183,255
+ActiveTextColor=207,214,219,255
 ActiveTextShadowColor=255,255,255,255
 ActiveUnfocusedTabColor=120,120,120
 
 InactiveFocusedTabColor=120,120,120
-InactiveTextColor=138,143,152,255
+InactiveTextColor=169,175,180,255
 InactiveTextShadowColor=255,255,255,255
 InactiveUnfocusedTabColor=120,120,120
 

--- a/color-schemes/Qogir.colors
+++ b/color-schemes/Qogir.colors
@@ -85,8 +85,8 @@ BackgroundAlternate=255,255,255
 BackgroundNormal=255,255,255
 DecorationFocus=66,133,244
 DecorationHover=142,203,233
-ForegroundActive=255,128,224
-ForegroundInactive=136,135,134
+ForegroundActive=61,174,233
+ForegroundInactive=102,106,115
 ForegroundLink=0,87,174
 ForegroundNegative=191,3,3
 ForegroundNeutral=176,128,0
@@ -104,8 +104,8 @@ contrast=0
 
 [WM]
 activeBackground=40,42,51
-activeBlend=50,52,61
-activeForeground=211,218,227
+activeBlend=40,42,51
+activeForeground=207,214,219
 inactiveBackground=40,42,51
-inactiveBlend=50,52,61
-inactiveForeground=120,124,129
+inactiveBlend=47,52,63
+inactiveForeground=169,175,180

--- a/color-schemes/Qogirmanjarodark.colors
+++ b/color-schemes/Qogirmanjarodark.colors
@@ -104,8 +104,8 @@ contrast=4
 
 [WM]
 activeBackground=40,42,51
-activeBlend=47,52,63
-activeForeground=211,218,227
+activeBlend=40,42,51
+activeForeground=207,214,219
 inactiveBackground=40,42,51
 inactiveBlend=47,52,63
-inactiveForeground=102,106,115
+inactiveForeground=169,175,180

--- a/color-schemes/Qogirubuntudark.colors
+++ b/color-schemes/Qogirubuntudark.colors
@@ -104,8 +104,8 @@ contrast=4
 
 [WM]
 activeBackground=40,42,51
-activeBlend=47,52,63
-activeForeground=211,218,227
+activeBlend=40,42,51
+activeForeground=207,214,219
 inactiveBackground=40,42,51
 inactiveBlend=47,52,63
-inactiveForeground=102,106,115
+inactiveForeground=169,175,180


### PR DESCRIPTION
CC: https://github.com/vinceliuice/Qogir-theme/blob/master/src/gtk-3.0/theme/gtk-dark.css#L10520

The issue with Aurorae is that it doesn't allow non-255 colors. Well, it does, but it doesn't work (it will be transparent to the whole background, not only to the title), so what I did was put a background of #282a33 on GIMP on one layer, then a foreground of #e4ebf1 and put it on 80% opacity, then grab the color using KColorChooser.

Same for the unfocused title, but that one used #e4ebf1 at 50% opacity. Cursed, I know.