### PR TITLE
Update shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SRC_DIR=$(cd $(dirname $0) && pwd)
 ROOT_UID=0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT_UID=0
 


### PR DESCRIPTION
你好，我把安装/卸载脚本的 shebang 修改成了 `#!/usr/bin/env bash`。因为在例如 NixOS 这类系统上 `/bin/bash` 这个路径是不存在的。它们严格遵循 POSIX 的规范和建议的关系，只有 `/bin/sh` 和 `/usr/bin/env` 这两个。这个修改几乎不会带来什么兼容性的下降，理论上还会提高。