### PR TITLE
Reduced TabFrame frames

### DIFF
--- a/Kvantum/Qogir-dark-solid/Qogir-dark-solid.kvconfig
+++ b/Kvantum/Qogir-dark-solid/Qogir-dark-solid.kvconfig
@@ -269,10 +269,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand

--- a/Kvantum/Qogir-dark/Qogir-dark.kvconfig
+++ b/Kvantum/Qogir-dark/Qogir-dark.kvconfig
@@ -284,10 +284,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand

--- a/Kvantum/Qogir-light-solid/Qogir-light-solid.kvconfig
+++ b/Kvantum/Qogir-light-solid/Qogir-light-solid.kvconfig
@@ -258,10 +258,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand

--- a/Kvantum/Qogir-light/Qogir-light.kvconfig
+++ b/Kvantum/Qogir-light/Qogir-light.kvconfig
@@ -268,10 +268,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand

--- a/Kvantum/Qogir-solid/Qogir-solid.kvconfig
+++ b/Kvantum/Qogir-solid/Qogir-solid.kvconfig
@@ -286,10 +286,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand

--- a/Kvantum/Qogir/Qogir.kvconfig
+++ b/Kvantum/Qogir/Qogir.kvconfig
@@ -296,10 +296,10 @@ frame.expansion=0
 inherits=PanelButtonCommand
 frame.element=tabframe
 interior.element=tabframe
-frame.top=4
-frame.bottom=4
-frame.left=4
-frame.right=4
+frame.top=1
+frame.bottom=1
+frame.left=1
+frame.right=1
 
 [TreeExpander]
 inherits=PanelButtonCommand


### PR DESCRIPTION
There is a problem with status bar in some apps. E.g. in Double Commander (doublecmd-qt) the text in status bar of panel is overlaped by its frames.

![2](https://user-images.githubusercontent.com/42656259/224399879-b7ccb557-fce5-4eae-a1d3-37a27d004fbb.png)